### PR TITLE
Broker side schema validation example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:${TAG}
+    image: confluentinc/cp-server:${TAG}
     hostname: broker
     container_name: broker
     depends_on:
@@ -31,6 +31,9 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
       KAFKA_JMX_PORT: 10099
       KAFKA_JMX_HOSTNAME: 0.0.0.0
+      ############################## My Schema Validation Demo Settings ################
+      # Schema Registry URL
+      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
 
   schema-registry:
     image: confluentinc/cp-schema-registry:${TAG}


### PR DESCRIPTION
Add a simple example of broker side schema validation and how the message is refused by the broker when the validation is enabled. It is based on a Confluent example (link added to the readme)